### PR TITLE
Simplify height in SpSpa use under Header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pithekos-lib",
-  "version": "0.6.5",
+  "version": "0.10.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pithekos-lib",
-      "version": "0.6.5",
+      "version": "0.10.9",
       "license": "MIT",
       "dependencies": {
         "@babel/cli": "^7.24.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pithekos-lib",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "private": false,
   "description": "Library functions for Pithekos",
   "main": "dist/index.js",

--- a/src/components/SpSpa.jsx
+++ b/src/components/SpSpa.jsx
@@ -11,7 +11,7 @@ function SpSpa({children, titleKey, requireNet, currentId, widget, margin}) {
                 requireNet={requireNet}
                 currentId={currentId}
                 widget={widget || null}
-                margin={margin || 2}
+                margin={margin || 0}
             >
                 {children}
             </SpSpaPage>

--- a/src/components/SpSpaPage.jsx
+++ b/src/components/SpSpaPage.jsx
@@ -40,7 +40,6 @@ function SpSpaPage({titleKey, widget, margin = 2, children, requireNet = false, 
             </Box>
             <Box sx={{
                 m: margin,
-                height: "100%",
                 overflowX: "hidden",
                 overflowY: "auto",
             }}>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fcf3bfd0-b14c-4129-8dd6-8152ae68504b)
### The above show **static** (unspecified) use of SpSpa **underneath the header**.
- An alternative solution to the instructions on the right above _in conjunction with_ consuming this PR, is to use a fixed position of:
- `<Box style={{position: 'fixed', top: '84px', bottom: 0, right: 0, overflow: 'scroll', width: '100%' }}>` (**scrolls into whitespace**)
&nbsp;&nbsp;&middot; Add a separate `<Box sx= {{pt:0, px:2, pb:2 }}>` wrapping everything immediately under it. _(Other approaches TBD)_
&nbsp;&nbsp;&middot; Converting style above to sx is under review.
 - `<Box style={{position: 'fixed', top: '48px', bottom: 0, right: 0, overflow: 'scroll', width: '100%' }}>` (**scrolls into header**)
&nbsp;&nbsp;&middot; Add a separate `<Box sx= {{p:2}}>` wrapping everything immediately under it. _(Other approaches TBD)_
&nbsp;&nbsp;&middot; Converting style above to sx is under review.
 
### The below shows **fixed** position use of SpSpa **underneath the header**.
![image](https://github.com/user-attachments/assets/829eb631-0762-42ed-8b35-26975ddefea8)
